### PR TITLE
Rewrite CLI using cppassist::CommandLineProgram

### DIFF
--- a/source/tools/glkernel-cli/main.cpp
+++ b/source/tools/glkernel-cli/main.cpp
@@ -3,20 +3,20 @@
 
 #include <cppassist/logging/logging.h>
 
+#include <glkernel/glkernel-version.h>
+
 #include <cppassist/cmdline/ArgumentParser.h>
 #include <cppassist/cmdline/CommandLineProgram.h>
 #include <cppassist/cmdline/CommandLineAction.h>
 #include <cppassist/cmdline/CommandLineCommand.h>
 #include <cppassist/cmdline/CommandLineOption.h>
-#include <cppassist/cmdline/CommandLineSwitch.h>
-#include <cppassist/cmdline/CommandLineParameter.h>
 
 
 int main(int argc, char* argv[])
 {
     auto program = cppassist::CommandLineProgram{
         "glkernel-cli",
-        "glkernel-cli", // TODO version, license?
+        "glkernel-cli " GLKERNEL_VERSION,
         "A command line interface for generating and converting kernels."};
 
 

--- a/source/tools/glkernel-cli/main.cpp
+++ b/source/tools/glkernel-cli/main.cpp
@@ -8,8 +8,8 @@
 #include <cppassist/cmdline/ArgumentParser.h>
 #include <cppassist/cmdline/CommandLineProgram.h>
 #include <cppassist/cmdline/CommandLineAction.h>
-#include <cppassist/cmdline/CommandLineCommand.h>
 #include <cppassist/cmdline/CommandLineOption.h>
+#include <cppassist/cmdline/CommandLineSwitch.h>
 
 
 int main(int argc, char* argv[])
@@ -20,69 +20,72 @@ int main(int argc, char* argv[])
         "A command line interface for generating and converting kernels."};
 
 
-    auto actionGenerate = cppassist::CommandLineAction{"generate", "Generate a kernel from a kernel description"};
-    auto actionConvert = cppassist::CommandLineAction{"convert", "Convert an existing kernel into another representation"};
+    auto actionRun = cppassist::CommandLineAction{"run",
+        "Generate a kernel from a kernel description or convert an existing kernel into another representation"};
 
-    auto commandGenerate = cppassist::CommandLineCommand{"generate"};
-    auto commandConvert = cppassist::CommandLineCommand{"convert"};
+    auto optInputFile = cppassist::CommandLineOption{
+        "--input",
+        "-i",
+        "inFileName",
+        "Kernel description or generated kernel",
+        cppassist::CommandLineOption::NonOptional};
 
-    auto optInputFile = cppassist::CommandLineOption{"--input", "-i", "inFileName",
-        "Kernel description or generated kernel", cppassist::CommandLineOption::NonOptional};
-    auto optOutputFile = cppassist::CommandLineOption{"--output", "-o", "outFileName",
-        "File that the generated / converted kernel will be written to", cppassist::CommandLineOption::NonOptional};
-    auto optOutputFormat = cppassist::CommandLineOption{"--format", "-f", "outFileFormat",
-        "File format for the generated / converted kernel (e.g. json, png)", cppassist::CommandLineOption::Optional};
+    auto optOutputFile = cppassist::CommandLineOption{
+        "--output",
+        "-o",
+        "outFileName",
+        "File that the generated / converted kernel will be written to",
+        cppassist::CommandLineOption::NonOptional};
 
-    actionGenerate.add(&commandGenerate);
-    actionGenerate.add(&optInputFile);
-    actionGenerate.add(&optOutputFile);
-    actionGenerate.add(&optOutputFormat);
+    auto optOutputFormat = cppassist::CommandLineOption{
+        "--format",
+        "-f",
+        "outFileFormat",
+        "File format for the generated / converted kernel (e.g. json, png)",
+        cppassist::CommandLineOption::Optional};
 
-    actionConvert.add(&commandConvert);
-    actionConvert.add(&optInputFile);
-    actionConvert.add(&optOutputFile);
-    actionConvert.add(&optOutputFormat);
+    auto swConvert = cppassist::CommandLineSwitch{
+        "--convert",
+        "-c",
+        "Convert an existing kernel into another representation instead of generating a new one",
+        cppassist::CommandLineSwitch::Optional};
 
-    program.add(&actionGenerate);
-    program.add(&actionConvert);
+
+    actionRun.add(&optInputFile);
+    actionRun.add(&optOutputFile);
+    actionRun.add(&optOutputFormat);
+    actionRun.add(&swConvert);
+
+    program.add(&actionRun);
 
     program.parse(argc, argv);
 
     if (program.selectedAction() && !program.hasErrors()) {
 
         // Generate kernel from description
-        if (program.selectedAction() == &actionGenerate) {
-            const auto& inFileName = optInputFile.value();
-            const auto& outFileName = optOutputFile.value();
-            auto outFileFormat = optOutputFormat.value();
-            if (outFileFormat.empty()) {
-                if (outFileName.find('.') == std::string::npos) {
-                    outFileFormat = "json";
-                } else {
-                    outFileFormat = outFileName.substr(outFileName.find_last_of('.') + 1);
-                }
-            }
-            cppassist::info() << "Using kernel description \"" << inFileName << "\" to generate kernel \"" << outFileName << "\" (format: " << outFileFormat << ")";
-        }
-
-        // Convert kernel to other representation
-        else if (program.selectedAction() == &actionConvert) {
-            const auto& inFileName = optInputFile.value();
-            const auto& outFileName = optOutputFile.value();
-            auto outFileFormat = optOutputFormat.value();
-            if (outFileFormat.empty()) {
+        const auto &inFileName = optInputFile.value();
+        const auto &outFileName = optOutputFile.value();
+        auto outFileFormat = optOutputFormat.value();
+        if (outFileFormat.empty()) {
+            if (outFileName.find('.') == std::string::npos) {
+                outFileFormat = "json";
+            } else {
                 outFileFormat = outFileName.substr(outFileName.find_last_of('.') + 1);
-                if (outFileName.find('.') == std::string::npos) {
-                    outFileFormat = "json";
-                } else {
-                    outFileFormat = outFileName.substr(outFileName.find_last_of('.') + 1);
-                }
             }
-            cppassist::info() << "Converting kernel \"" << inFileName << "\" to output file \"" << outFileName << "\" (format: " << outFileFormat << ")";
         }
 
-        // Success
+        if (swConvert.activated()) {
+            // Convert kernel to other representation
+            cppassist::info() << "Converting kernel \"" << inFileName << "\" to output file \"" << outFileName
+                              << "\" (format: " << outFileFormat << ")";
+        } else {
+            // Generate kernel from description
+            cppassist::info() << "Using kernel description \"" << inFileName << "\" to generate kernel \""
+                              << outFileName << "\" (format: " << outFileFormat << ")";
+        }
+
         return 0;
+        // Success
     }
 
     else {

--- a/source/tools/glkernel-cli/main.cpp
+++ b/source/tools/glkernel-cli/main.cpp
@@ -1,28 +1,103 @@
 #include <iostream>
 #include <string>
 
+#include <cppassist/logging/logging.h>
+
 #include <cppassist/cmdline/ArgumentParser.h>
+#include <cppassist/cmdline/CommandLineProgram.h>
+#include <cppassist/cmdline/CommandLineAction.h>
+#include <cppassist/cmdline/CommandLineCommand.h>
+#include <cppassist/cmdline/CommandLineOption.h>
+#include <cppassist/cmdline/CommandLineSwitch.h>
+#include <cppassist/cmdline/CommandLineParameter.h>
 
 
 int main(int argc, char* argv[])
 {
-    cppassist::ArgumentParser argParser;
-    argParser.parse(argc, argv);
+    auto program = cppassist::CommandLineProgram{
+        "glkernel-cli",
+        "glkernel-cli", // TODO version, license?
+        "A command line interface for generating and converting kernels."};
 
-    auto inFileName = argParser.value("--input");
-    auto outFileName = argParser.value("--output");
 
-    auto outFileType = outFileName.substr(outFileName.find_last_of('.') + 1);
+    auto actionGenerate = cppassist::CommandLineAction{"generate", "Generate a kernel from a kernel description"};
+    auto actionConvert = cppassist::CommandLineAction{"convert", "Convert an existing kernel into another representation"};
 
-    auto fromGeneratedKernel = argParser.isSet("-k");
+    auto commandGenerate = cppassist::CommandLineCommand{"generate"};
+    auto commandConvert = cppassist::CommandLineCommand{"convert"};
 
-    if (fromGeneratedKernel)
-    {
-        std::cout << "Converting kernel \"" << inFileName << "\" to output file \"" << outFileName << "\" (type: " << outFileType << ")" <<std::endl;
+    auto optInputFile = cppassist::CommandLineOption{"--input", "-i", "inFileName",
+        "Kernel description or generated kernel", cppassist::CommandLineOption::NonOptional};
+    auto optOutputFile = cppassist::CommandLineOption{"--output", "-o", "outFileName",
+        "File that the generated / converted kernel will be written to", cppassist::CommandLineOption::NonOptional};
+    auto optOutputFormat = cppassist::CommandLineOption{"--format", "-f", "outFileFormat",
+        "File format for the generated / converted kernel (e.g. json, png)", cppassist::CommandLineOption::Optional};
+
+    actionGenerate.add(&commandGenerate);
+    actionGenerate.add(&optInputFile);
+    actionGenerate.add(&optOutputFile);
+    actionGenerate.add(&optOutputFormat);
+
+    actionConvert.add(&commandConvert);
+    actionConvert.add(&optInputFile);
+    actionConvert.add(&optOutputFile);
+    actionConvert.add(&optOutputFormat);
+
+    program.add(&actionGenerate);
+    program.add(&actionConvert);
+
+    program.parse(argc, argv);
+
+    if (program.selectedAction() && !program.hasErrors()) {
+
+        // Generate kernel from description
+        if (program.selectedAction() == &actionGenerate) {
+            const auto& inFileName = optInputFile.value();
+            const auto& outFileName = optOutputFile.value();
+            auto outFileFormat = optOutputFormat.value();
+            if (outFileFormat.empty()) {
+                if (outFileName.find('.') == std::string::npos) {
+                    outFileFormat = "json";
+                } else {
+                    outFileFormat = outFileName.substr(outFileName.find_last_of('.') + 1);
+                }
+            }
+            cppassist::info() << "Using kernel description \"" << inFileName << "\" to generate kernel \"" << outFileName << "\" (format: " << outFileFormat << ")";
+        }
+
+        // Convert kernel to other representation
+        else if (program.selectedAction() == &actionConvert) {
+            const auto& inFileName = optInputFile.value();
+            const auto& outFileName = optOutputFile.value();
+            auto outFileFormat = optOutputFormat.value();
+            if (outFileFormat.empty()) {
+                outFileFormat = outFileName.substr(outFileName.find_last_of('.') + 1);
+                if (outFileName.find('.') == std::string::npos) {
+                    outFileFormat = "json";
+                } else {
+                    outFileFormat = outFileName.substr(outFileName.find_last_of('.') + 1);
+                }
+            }
+            cppassist::info() << "Converting kernel \"" << inFileName << "\" to output file \"" << outFileName << "\" (format: " << outFileFormat << ")";
+        }
+
+        // Success
+        return 0;
     }
-    else
-    {
-        std::cout << "Using kernel description \"" << inFileName << "\" to generate kernel \"" << outFileName << "\" (type: " << outFileType << ")" << std::endl;
+
+    else {
+        // Print help
+        program.print(program.help(program.selectedAction()));
+
+        // Print errors
+        if (program.hasErrors() && program.selectedAction())
+        {
+            std::string error = program.selectedAction()->errors()[0];
+            program.print("Error: " + error);
+
+            return 1;
+        }
     }
 
+    return 0;
 }


### PR DESCRIPTION
Implement requirements from #1 using CommandLineProgram

example usage:

```
$ ./glkernel-clid convert -i infile.json -o outfile.png -f png
Converting kernel "infile.json" to output file "outfile.png" (format: png)

$ ./glkernel-clid convert -i infile.json -o outfile.png
Converting kernel "infile.json" to output file "outfile.png" (format: png)

$ ./glkernel-clid convert -i infile.json -o outfile
Converting kernel "infile.json" to output file "outfile" (format: json)

$ ./glkernel-clid generate -i kernel.json -o outfile.png -f png
Using kernel description "kernel.json" to generate kernel "outfile.png" (format: png)
```